### PR TITLE
Startup performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,19 @@ To check if the plugin is working correctly:
 3. After the downloads, a sample made of three layers should open in the viewer
 
 ### GPU Support
-If you want to use GPU acceleration for model inference...
+Model inference runs on the CPU by default. CPU inference works everywhere but is slow on large images; enabling GPU acceleration is strongly recommended if you have a compatible GPU.
 
-**On Linux and Windows systems:**
-1. Ensure you have the proper GPU drivers and CUDA installed for your system:
-   - [NVIDIA CUDA Installation Guide Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)
-   - [NVIDIA CUDA Installation Guide Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html)
+**On Linux and Windows systems (NVIDIA GPUs):**
+The default installation ships a CPU-only build of PyTorch. To enable your NVIDIA GPU, reinstall PyTorch from the CUDA wheel index:
 
-2. You may need to reinstall PyTorch with CUDA support for your specific hardware:
-   Visit the [PyTorch Installation Guide](https://pytorch.org/get-started/locally/) to find the appropriate installation command for your setup.
+```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+```
+
+This single command covers all recent NVIDIA GPUs (RTX 20-series and newer, including the RTX 50-series); the CUDA runtime is bundled with the wheels, so no separate CUDA toolkit installation is required. You only need an up-to-date NVIDIA driver ([Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/), [Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html)). For older GPUs or drivers, pick the matching command from the [PyTorch Installation Guide](https://pytorch.org/get-started/locally/) instead.
 
 **On macOS:**
-1. CUDA is not available for macOS, however, PyTorch is supporting GPU acceleration for Apple Silicon devices (M1 and newer) via MPS. There is no need to install drivers or CUDA. Note that the MPS acceleration can currently only be leveraged for the cell segmentation model.
+CUDA is not available for macOS, however, PyTorch is supporting GPU acceleration for Apple Silicon devices (M1 and newer) via MPS. There is no need to install drivers or CUDA. Note that the MPS acceleration can currently only be leveraged for the cell segmentation model.
 
 Finally, enable GPU support in the napari-roxas-ai settings within the napari interface. Go to `Plugins > ROXAS AI > ZZ - Settings` and under `processing` change the variables `try_to_use_gpu` and `try_to_use_autocast` to `true`. You may need to restart the application for changes to take effect.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,22 @@ dependencies = [
     "rasterio==1.4.3",
     "scikit-image>=0.24.0,<=0.25.2",
     "matplotlib>=3.9.4,<=3.10.1",
-    # Linux (CUDA 12.1)
+    # NOTE: the CPU vs CUDA build is selected at install time via the wheel
+    # source (the default PyPI wheels are CPU-only on Linux/Windows). For
+    # NVIDIA GPUs reinstall from the matching PyTorch index, e.g. Blackwell
+    # (RTX 50-series, sm_120) needs CUDA 12.8:
+    #   pip install --index-url https://download.pytorch.org/whl/cu128 torch torchvision
+    # The torch/torchvision version pairs below must stay compatible
+    # (e.g. torch 2.8 <-> torchvision 0.23).
+    # Linux
     "torch>=2.2.0,<2.9.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
     "torchvision>=0.17.0,<0.24.0 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    # Windows (CUDA 12.1)
+    # Windows
     "torch>=2.2.0,<2.9.0 ; sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "torchvision>=0.17.0,<0.22.0 ; sys_platform == 'win32' and platform_machine == 'AMD64'",
-    # macOS/ARM (CPU-only fallback)
+    "torchvision>=0.17.0,<0.24.0 ; sys_platform == 'win32' and platform_machine == 'AMD64'",
+    # macOS/ARM (CPU/MPS)
     "torch>=2.4.0,<2.9.0 ; sys_platform == 'darwin' or platform_machine == 'arm64'",
-    "torchvision>=0.17.0,<0.22.0 ; sys_platform == 'darwin' or platform_machine == 'arm64'",
+    "torchvision>=0.17.0,<0.24.0 ; sys_platform == 'darwin' or platform_machine == 'arm64'",
     "pytorch-lightning==2.6.0",
     "segmentation-models-pytorch==0.4.0",
     "albumentations==2.0.5",

--- a/src/napari_roxas_ai/__init__.py
+++ b/src/napari_roxas_ai/__init__.py
@@ -1,40 +1,61 @@
-__version__ = "0.1.2"
-from ._conversion import cells_vectorization_widget
-from ._crossdating import CrossDatingPlotterWidget
-from ._edition import CellsLayerEditorWidget, RingsLayerEditorWidget
-from ._loading import SamplesLoadingWidget
-from ._measurements import (
-    BatchSampleMeasurementsWidget,
-    SingleSampleMeasurementsWidget,
-)
-from ._preparation import PreparationWidget
-from ._project_directory import open_project_directory_dialog
-from ._reader import napari_get_reader
-from ._sample_data import load_sample_data
-from ._saving import SamplesSavingWidget
-from ._segmentation import (
-    BatchSampleSegmentationWidget,
-    SingleSampleSegmentationWidget,
-)
-from ._settings import open_settings_file
-from ._writer import write_multiple_layers, write_single_layer
+"""napari-roxas-ai plugin package.
 
-__all__ = (
-    "CrossDatingPlotterWidget",
-    "SingleSampleMeasurementsWidget",
-    "BatchSampleMeasurementsWidget",
-    "SamplesLoadingWidget",
-    "SamplesSavingWidget",
-    "SingleSampleSegmentationWidget",
-    "BatchSampleSegmentationWidget",
-    "PreparationWidget",
-    "open_project_directory_dialog",
-    "CellsLayerEditorWidget",
-    "RingsLayerEditorWidget",
-    "cells_vectorization_widget",
-    "load_sample_data",
-    "open_settings_file",
-    "napari_get_reader",
-    "write_single_layer",
-    "write_multiple_layers",
-)
+Public widget/contribution objects are imported lazily (PEP 562) so that
+opening any single widget only pulls in that widget's own dependencies.
+
+Previously every ``python_name`` in ``napari.yaml`` pointed at this package
+root, so opening *any* widget executed this module and eagerly imported all
+submodules -- including the heavy ML stack (torch, pytorch-lightning,
+segmentation-models-pytorch) via ``._segmentation``. That made the first
+widget of any kind take ~10 s. With lazy access the heavy stack is only
+imported when a segmentation widget is actually opened.
+"""
+
+import importlib
+
+__version__ = "0.1.2"
+
+# Public attribute name -> submodule that defines it.
+# Mirrors the ``python_name`` references in napari.yaml and the previous
+# eager imports / ``__all__`` of this module.
+_LAZY_IMPORTS = {
+    "cells_vectorization_widget": "._conversion",
+    "CrossDatingPlotterWidget": "._crossdating",
+    "CellsLayerEditorWidget": "._edition",
+    "RingsLayerEditorWidget": "._edition",
+    "SamplesLoadingWidget": "._loading",
+    "BatchSampleMeasurementsWidget": "._measurements",
+    "SingleSampleMeasurementsWidget": "._measurements",
+    "PreparationWidget": "._preparation",
+    "open_project_directory_dialog": "._project_directory",
+    "napari_get_reader": "._reader",
+    "load_sample_data": "._sample_data",
+    "SamplesSavingWidget": "._saving",
+    "BatchSampleSegmentationWidget": "._segmentation",
+    "SingleSampleSegmentationWidget": "._segmentation",
+    "open_settings_file": "._settings",
+    "write_multiple_layers": "._writer",
+    "write_single_layer": "._writer",
+}
+
+__all__ = tuple(_LAZY_IMPORTS)
+
+
+def __getattr__(name):
+    """Lazily import public attributes on first access (PEP 562)."""
+    try:
+        module_name = _LAZY_IMPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        ) from None
+
+    module = importlib.import_module(module_name, __name__)
+    attr = getattr(module, name)
+    # Cache on the package so subsequent lookups skip __getattr__ entirely.
+    globals()[name] = attr
+    return attr
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_IMPORTS))

--- a/src/napari_roxas_ai/_edition/_rings_layer_editor.py
+++ b/src/napari_roxas_ai/_edition/_rings_layer_editor.py
@@ -5,7 +5,6 @@ import cv2
 import napari.layers
 import numpy as np
 import pandas as pd
-import torch
 from magicgui.widgets import (
     ComboBox,
     Container,
@@ -16,7 +15,6 @@ from napari.utils.notifications import show_info
 from PIL import Image
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QMessageBox
-from torch.package import PackageImporter
 
 from napari_roxas_ai._settings import SettingsManager
 from napari_roxas_ai._utils import make_rings_colormap
@@ -819,6 +817,13 @@ class RingsLayerEditorWidget(Container):
             f"Rerunning model from year {selected_year} "
             f"(boundary with {len(start_boundary)} vertices)"
         )
+
+        # Heavy ML imports are deferred to run time: importing torch at module
+        # level would drag the whole ML stack into every widget that imports
+        # this module (e.g. update_rings_geometries is used by the segmentation
+        # widgets), slowing widget opening. Import only when actually running.
+        import torch
+        from torch.package import PackageImporter
 
         # Set up rings model
         rings_model = PackageImporter(

--- a/src/napari_roxas_ai/_segmentation/__init__.py
+++ b/src/napari_roxas_ai/_segmentation/__init__.py
@@ -1,7 +1,3 @@
-from pathlib import Path
-
-from napari_roxas_ai._assets_files import check_assets_and_download
-
 from ._batch_sample_segmentation import BatchSampleSegmentationWidget
 from ._single_sample_segmentation import SingleSampleSegmentationWidget
 
@@ -10,11 +6,6 @@ __all__ = [
     "BatchSampleSegmentationWidget",
 ]
 
-
-BASE_DIR = Path(__file__).parent.absolute()
-check_assets_and_download(
-    str(BASE_DIR / "_models" / "_cells"), "cells_models.zip"
-)
-check_assets_and_download(
-    str(BASE_DIR / "_models" / "_rings"), "rings_models.zip"
-)
+# NOTE: model weights are downloaded lazily by each segmentation widget's
+# __init__ (see check_assets_and_download calls there) instead of at import
+# time, so importing this package never triggers network/filesystem I/O.

--- a/src/napari_roxas_ai/_segmentation/_batch_sample_segmentation.py
+++ b/src/napari_roxas_ai/_segmentation/_batch_sample_segmentation.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import pandas as pd
-import torch
 from magicgui.widgets import (
     CheckBox,
     ComboBox,
@@ -15,17 +14,22 @@ from magicgui.widgets import (
 from PIL import Image
 from qtpy.QtCore import QObject, QThread, Signal
 from qtpy.QtWidgets import QFileDialog, QMessageBox
-from torch.package import PackageImporter
 
+from napari_roxas_ai._assets_files import check_assets_and_download
 from napari_roxas_ai._edition import update_rings_geometries
 from napari_roxas_ai._reader import get_metadata_from_file, read_scan_file
 from napari_roxas_ai._settings import SettingsManager
 from napari_roxas_ai._writer import write_single_layer
 
-from ._cells_model import CellsSegmentationModel
 from ._single_sample_segmentation import apply_segmentation_results_to_viewer
 from .._utils._fix_sample_stem_path import fix_sample_stem_paths_in_project
 from .._utils._segmentation_postprocess import remove_border_touching_components
+
+# NOTE: torch, torch.package.PackageImporter and ._cells_model.CellsSegmentationModel
+# are intentionally imported lazily inside Worker.__init__ / Worker.run() instead of
+# at module level. They pull in the heavy ML stack (torch / pytorch-lightning /
+# segmentation-models-pytorch) which is the dominant import cost, so deferring it
+# keeps opening this widget fast; the cost is paid only when segmentation runs.
 
 if TYPE_CHECKING:
     import napari
@@ -54,6 +58,13 @@ class Worker(QObject):
         rings_model_weights_file: Optional[str] = None,
     ):
         super().__init__()
+
+        # Heavy ML imports are deferred to worker construction (see module note).
+        import torch
+        from torch.package import PackageImporter
+
+        from ._cells_model import CellsSegmentationModel
+
         self.input_directory_path = input_directory_path
         self.segment_cells = segment_cells
         self.segment_rings = segment_rings
@@ -155,6 +166,9 @@ class Worker(QObject):
                 fix_sample_stem_paths_in_project(self.input_directory_path)
 
     def run(self):
+        # Heavy ML imports are deferred to run time (see module note).
+        import torch
+
         # Prevent OpenMP crash when running inside a QThread with PyQt6 on macOS
         torch.set_num_threads(1)
 
@@ -261,6 +275,11 @@ class BatchSampleSegmentationWidget(Container):
     def __init__(self, viewer: "napari.viewer.Viewer"):
         super().__init__()
         self._viewer = viewer
+
+        # Ensure model weights are present before listing them below.
+        # (Moved out of import time; only downloads if the dirs are missing.)
+        check_assets_and_download(str(CELLS_MODELS_PATH), "cells_models.zip")
+        check_assets_and_download(str(RINGS_MODELS_PATH), "rings_models.zip")
 
         # Get input directory
         self.input_directory_path = settings.get("project_directory")

--- a/src/napari_roxas_ai/_segmentation/_single_sample_segmentation.py
+++ b/src/napari_roxas_ai/_segmentation/_single_sample_segmentation.py
@@ -6,7 +6,6 @@ import napari.layers
 import numpy as np
 from scipy import ndimage as ndi
 import pandas as pd
-import torch
 from magicgui.widgets import (
     CheckBox,
     ComboBox,
@@ -17,16 +16,21 @@ from napari.utils.notifications import show_info
 from PIL import Image
 from qtpy.QtCore import QObject, QThread, Signal
 from qtpy.QtWidgets import QMessageBox
-from torch.package import PackageImporter
 
+from napari_roxas_ai._assets_files import check_assets_and_download
 from napari_roxas_ai._edition import update_rings_geometries
 from napari_roxas_ai._reader import get_metadata_from_file
 from napari_roxas_ai._settings import SettingsManager
 from napari_roxas_ai._utils import make_binary_labels_colormap
 
-from ._cells_model import CellsSegmentationModel
 from .._utils._fix_sample_stem_path import fix_sample_stem_paths_in_project
 from .._utils._segmentation_postprocess import remove_border_touching_components
+
+# NOTE: torch, torch.package.PackageImporter and ._cells_model.CellsSegmentationModel
+# are intentionally imported lazily inside Worker.run() instead of at module level.
+# They pull in the heavy ML stack (torch / pytorch-lightning /
+# segmentation-models-pytorch) which is the dominant import cost, so deferring it
+# keeps opening this widget fast; the cost is paid only when segmentation runs.
 
 if TYPE_CHECKING:
     import napari
@@ -223,6 +227,12 @@ class Worker(QObject):
         self.base_name = base_name
 
     def run(self):
+        # Heavy ML imports are deferred to run time (see module-level note).
+        import torch
+        from torch.package import PackageImporter
+
+        from ._cells_model import CellsSegmentationModel
+
         # Prevent OpenMP crash when running inside a QThread with PyQt6 on macOS
         torch.set_num_threads(1)
 
@@ -341,6 +351,11 @@ class SingleSampleSegmentationWidget(Container):
         super().__init__()
         self._viewer = viewer
         self.settings = SettingsManager()
+
+        # Ensure model weights are present before listing them below.
+        # (Moved out of import time; only downloads if the dirs are missing.)
+        check_assets_and_download(str(CELLS_MODELS_PATH), "cells_models.zip")
+        check_assets_and_download(str(RINGS_MODELS_PATH), "rings_models.zip")
 
         # Create a layer selection widget filtered by scan extension
         self._input_layer_combo = ComboBox(


### PR DESCRIPTION
Lazy-load heavy ML imports (torch, torchvision, scipy) so that opening a widget no longer pulls in the full inference stack, reducing first-widget startup from ~10s to near-instant. Also bumps the torchvision pin to <0.24.0 for Blackwell/torch 2.8 GPU support and simplifies the README GPU install instructions to a single cu128 command.    